### PR TITLE
Adding CGPFunction module as an option in config reader

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -6,12 +6,18 @@ function get_config(config::Dict)
     # parse all function names, assign to function value
     two_arity = falses(length(config["functions"]))
     functions = Array{Function}(undef, length(config["functions"]))
+    # use function_module if given (default is CGPFunctions)
+    if "function_module" in keys(config)
+        function_module = config["function_module"]
+    else
+        function_module = CGPFunctions
+    end
     for i in eachindex(config["functions"])
         fname = config["functions"][i]
-        if CGPFunctions.arity[fname] == 2
+        if function_module.arity[fname] == 2
             two_arity[i] = true
         end
-        functions[i] = eval(Meta.parse(string("CGPFunctions.", fname)))
+        functions[i] = getfield(function_module, Symbol(fname))
     end
     config["two_arity"] = two_arity
     config["functions"] = functions


### PR DESCRIPTION
Usage: provide the function module as an argument of `get_config` (default is `CartesianGeneticProgramming.CGPFunctions`) :
```
cfg = CartesianGeneticProgramming.get_config(args["cfg"]; function_module=IICGP.CGPFunctions, n_in=n_in, n_out=n_out)
```